### PR TITLE
Upgrade gqlparser to v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.4.0
-	github.com/vektah/gqlparser v1.3.1
+	github.com/vektah/gqlparser/v2 v2.2.0
 	golang.org/x/net v0.0.0-20201029055024-942e2f445f3c
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 	gopkg.in/yaml.v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/vektah/gqlparser v1.3.1 h1:8b0IcD3qZKWJQHSzynbDlrtP3IxVydZ2DZepCGofqf
 github.com/vektah/gqlparser v1.3.1/go.mod h1:bkVf0FX+Stjg/MHnm8mEyubuaArhNEqfQhF+OTiAL74=
 github.com/vektah/gqlparser/v2 v2.1.0 h1:uiKJ+T5HMGGQM2kRKQ8Pxw8+Zq9qhhZhz/lieYvCMns=
 github.com/vektah/gqlparser/v2 v2.1.0/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
+github.com/vektah/gqlparser/v2 v2.2.0 h1:bAc3slekAAJW6sZTi07aGq0OrfaCjj4jxARAaC7g2EM=
+github.com/vektah/gqlparser/v2 v2.2.0/go.mod h1:i3mQIGIrbK2PD1RrCeMTlVbkF2FJ6WkU1KJlJlC+3F4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=

--- a/gql/errors.go
+++ b/gql/errors.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // NewUnauthorizedError creates a new instance of Unauthorized error with the given context and message
@@ -20,17 +20,15 @@ func NewForbiddenError(ctx context.Context, message *string) *gqlerror.Error {
 	return newError(ctx, message, http.StatusForbidden)
 }
 
-func getGQLPath(ctx context.Context) []interface{} {
-	paths := graphql.GetPath(ctx)
-	iPaths := make([]interface{}, len(paths))
-	for i, path := range paths {
-		iPaths[i] = path
-	}
-	return iPaths
+// NewResourceNotFoundError creates a new instance of ResourceNotFound error with the given context and message
+// StatusResourceNotFound (4004) is used instead of http.StatusNotFound
+func NewResourceNotFoundError(ctx context.Context, message *string) *gqlerror.Error {
+
+	return newError(ctx, message, StatusResourceNotFound)
 }
 
 func newError(ctx context.Context, message *string, errorCode int) *gqlerror.Error {
-	path := getGQLPath(ctx)
+	path := graphql.GetPath(ctx)
 
 	return &gqlerror.Error{
 		Path:    path,

--- a/gql/status.go
+++ b/gql/status.go
@@ -1,0 +1,6 @@
+package gql
+
+const (
+	// StatusResourceNotFound indicates the requested resource is not found
+	StatusResourceNotFound = 4004
+)


### PR DESCRIPTION
Cause: the `Extension` field (containing the error code) in gqlerror is not delivered to the gql clients
- The gqlparser lib is used by gqlgen and is also used in apputils direclty
  to create gql errors.
- apputils has the latest gqlgen (v0.13.0) and this version of gqlgen is referencing
  gqlparser (v2.1.0)
- apputils is referencing an old version of gqlparser (v1), which is causing the error
  type incompatibility